### PR TITLE
Bugfix preventing the reset of the remote device

### DIFF
--- a/termios_unix.go
+++ b/termios_unix.go
@@ -89,6 +89,7 @@ func setTermSettingRawMode(settings *unix.Termios) {
 	// Set local mode
 	settings.Cflag |= unix.CREAD
 	settings.Cflag |= unix.CLOCAL
+	settings.Cflag &^= unix.HUPCL
 
 	// Set raw mode
 	settings.Lflag &^= unix.ICANON


### PR DESCRIPTION
For many devices that use the DTR line as a reset signal, it is not a good idea to always keep resetting the device on every connection. A new connection (by a new instance of the host program) might be made at any time and therefore the execution state on the connected device should be preserved. On Linux, the device is always reset automatically, if the Hangup flag is not disabled.
I hope this will be integrated soon :-)