### PR TITLE
Supported extended baudrate in OSX (darwin).

### DIFF
--- a/serial_termsettings_darwin.go
+++ b/serial_termsettings_darwin.go
@@ -4,9 +4,13 @@
 // license that can be found in the LICENSE file.
 //
 
-// +build freebsd openbsd
+// +build darwin
 
 package serial
+
+// #include <sys/ioctl.h>
+// #include <IOKit/serial/ioss.h>
+import "C"
 
 import (
 	"unsafe"
@@ -15,15 +19,21 @@ import (
 )
 
 func (p *Port) retrieveTermSettings() (*settings, error) {
-	s := &settings{termios: new(unix.Termios)}
+	s := &settings{termios: new(unix.Termios), specificBaudrate: 0}
 	if err := ioctl(p.internal.handle, ioctlTcgetattr, uintptr(unsafe.Pointer(s.termios))); err != nil {
 		return nil, newOSError(err)
 	}
+	speed := C.cfgetispeed((*C.struct_termios)(unsafe.Pointer(s.termios)))
+	s.specificBaudrate = int(speed)
 	return s, nil
 }
 
 func (p *Port) applyTermSettings(s *settings) error {
+	speed := C.speed_t(s.specificBaudrate)
 	if err := ioctl(p.internal.handle, ioctlTcsetattr, uintptr(unsafe.Pointer(s.termios))); err != nil {
+		return newOSError(err)
+	}
+	if err := ioctl(p.internal.handle, C.IOSSIOSPEED, uintptr(unsafe.Pointer(&speed))); err != nil {
 		return newOSError(err)
 	}
 	return nil

--- a/termios_baudrate_darwin.go
+++ b/termios_baudrate_darwin.go
@@ -1,0 +1,14 @@
+//
+// Copyright 2014-2017 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build darwin
+
+package serial
+
+func (s *settings) setBaudrate(speed int) error {
+	s.specificBaudrate = speed
+	return nil
+}

--- a/termios_baudrate_unix.go
+++ b/termios_baudrate_unix.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-// +build darwin freebsd openbsd
+// +build freebsd openbsd
 
 package serial
 

--- a/termios_setting_darwin.go
+++ b/termios_setting_darwin.go
@@ -1,0 +1,18 @@
+//
+// Copyright 2014-2017 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build darwin
+
+package serial
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+type settings struct {
+	termios          *unix.Termios
+	specificBaudrate int
+}

--- a/termios_setting_unix.go
+++ b/termios_setting_unix.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2014-2017 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// +build linux freebsd openbsd
+
+package serial
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+type settings struct {
+	termios *unix.Termios
+}

--- a/termios_unix.go
+++ b/termios_unix.go
@@ -12,10 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type settings struct {
-	termios *unix.Termios
-}
-
 func (s *settings) setParity(parity Parity) error {
 	switch parity {
 	case NoParity:


### PR DESCRIPTION
Thank you for creating this useful library.

I found that in OSX(darwin) I can not set higher than 230400 baud.
But almost of all USB-to-serial chip support higher than 230400 and I am used to work with it in OSX.

I investigated a little and found that OSX can set higher baudrate by using `ioctl(fd, IOSSIOSPEED, &speed)`. So I supported it.

This code is working in my own project.

Best.