### PR TITLE
Add support for darwin/arm64

### DIFF
--- a/constants_darwin_64.go
+++ b/constants_darwin_64.go
@@ -4,6 +4,9 @@
 // that can be found in the LICENSE file.
 //
 
+// +build darwin
+// +build amd64 arm64
+
 package serial
 
 import "golang.org/x/sys/unix"


### PR DESCRIPTION
This resolves albenik/go-serial#24 by using the same constants for arm64 as with amd64 on darwin.