### PR TITLE
Add support for linux/ppc64le

### DIFF
--- a/serial_termsettings_linux_ppc64le.go
+++ b/serial_termsettings_linux_ppc64le.go
@@ -3,9 +3,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //
+// linux/ppc64le specific implementation, that does not use TCGETS2 or TCSETS2,
+// as they are not supported by golang v1.18 for that platform circa 2022-03.
+// Code is identical to android implementation.
 
-//go:build linux && !android && !ppc64le
-// +build linux,!android,!ppc64le
+//go:build ppc64le
+// +build ppc64le
 
 package serial
 
@@ -22,22 +25,11 @@ func (p *Port) retrieveTermSettings() (s *settings, err error) {
 		return nil, newPortOSError(err)
 	}
 
-	if s.termios.Cflag&unix.BOTHER == unix.BOTHER {
-		if s.termios, err = unix.IoctlGetTermios(p.internal.handle, unix.TCGETS2); err != nil {
-			return nil, newPortOSError(err)
-		}
-	}
-
 	return s, nil
 }
 
 func (p *Port) applyTermSettings(s *settings) error {
-	req := uint(unix.TCSETS)
-	if s.termios.Cflag&unix.BOTHER == unix.BOTHER {
-		req = unix.TCSETS2
-	}
-
-	if err := unix.IoctlSetTermios(p.internal.handle, req, s.termios); err != nil {
+	if err := unix.IoctlSetTermios(p.internal.handle, unix.TCSETS, s.termios); err != nil {
 		return newPortOSError(err)
 	}
 


### PR DESCRIPTION
Hello @albenik --

This is a patch to add linux/ppc64le support to go-serial; builds were previously failing Debian tests.  
- https://ci.debian.net/packages/g/golang-github-albenik-go-serial/testing/ppc64el/
- https://ci.debian.net/data/autopkgtest/testing/ppc64el/g/golang-github-albenik-go-serial/20409929/log.gz

Unfortunately, the patch is very similar to the recent `serial_termsettings_android.go` code added.  Simply adding Golang "//go:build" statements to the android code did not function, thus a new file for ppc64le is created.  

Welcome feedback or alternate solutions.  Hope you're well.