### PR TITLE
Add support for loong64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 2.0.0
 
-* New Go Module import path `github.com/albenik/go-serial/v2`
+* New Go Module import path `github.com/bclswl0827/go-serial/v2`
 * `serial.Port` interface discarded in favor of `serial.Port` structure (similar to `os.File`)
 * `serial.Mode` discared and replaced with `serial.Option`
 * `serial.Open()` method changed to use `serila.Option`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github.com/albenik/go-serial/v2
+# github.com/bclswl0827/go-serial/v2
 
 ![Go](https://github.com/albenik/go-serial/workflows/Go/badge.svg)
 
@@ -15,7 +15,7 @@ Any PR-s are welcome.
 Not work in GOPATH mode!!!
 
 ```
-go get -u github.com/albenik/go-serial/v2
+go get -u github.com/bclswl0827/go-serial/v2
 ```
 
 ## MacOS build note
@@ -25,7 +25,7 @@ go get -u github.com/albenik/go-serial/v2
 
 ## Documentation and examples
 
-See the godoc here: https://pkg.go.dev/github.com/albenik/go-serial/v2
+See the godoc here: https://pkg.go.dev/github.com/bclswl0827/go-serial/v2
 
 ## License
 

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@
 
 Package go-serial is a cross-platform serial library for the go language.
 
-	import github.com/albenik/go-serial/v2
+	import github.com/bclswl0827/go-serial/v2
 
 It is possible to get the list of available serial ports with the
 GetPortsList function:
@@ -81,7 +81,7 @@ cable or a microcontroller development board) is possible to retrieve
 the USB metadata, like VID/PID or USB Serial Number, with the
 GetDetailedPortsList function in the enumerator package:
 
-	import "github.com/albenik/go-serial/v2/enumerator"
+	import "github.com/bclswl0827/go-serial/v2/enumerator"
 
 	ports, err := enumerator.GetDetailedPortsList()
 	if err != nil {

--- a/enumerator/example_getdetailedportlist_test.go
+++ b/enumerator/example_getdetailedportlist_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/albenik/go-serial/v2/enumerator"
+	"github.com/bclswl0827/go-serial/v2/enumerator"
 )
 
 func ExampleGetDetailedPortsList() {

--- a/enumerator/usb_linux.go
+++ b/enumerator/usb_linux.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/albenik/go-serial/v2"
+	"github.com/bclswl0827/go-serial/v2"
 )
 
 func nativeGetDetailedPortsList() ([]*PortDetails, error) {

--- a/example_getportlist_test.go
+++ b/example_getportlist_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/albenik/go-serial/v2"
+	"github.com/bclswl0827/go-serial/v2"
 )
 
 func ExampleGetPortsList() {

--- a/example_modem_bits_test.go
+++ b/example_modem_bits_test.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/albenik/go-serial/v2"
+	"github.com/bclswl0827/go-serial/v2"
 )
 
 func ExamplePort_GetModemStatusBits() {

--- a/example_serialport_test.go
+++ b/example_serialport_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/albenik/go-serial/v2"
+	"github.com/bclswl0827/go-serial/v2"
 )
 
 func ExamplePort_Reconfigure() {

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/albenik/go-serial/v2"
+	"github.com/bclswl0827/go-serial/v2"
 )
 
 // This example prints the list of serial ports and use the first one

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/albenik/go-serial/v2
+module github.com/bclswl0827/go-serial/v2
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/albenik/go-serial/v2
 go 1.18
 
 require (
-	github.com/creack/goselect v0.1.2
+	github.com/creack/goselect v0.1.3-0.20221130125424-8eac7f782437
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/multierr v1.9.0
 	golang.org/x/sys v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
-github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
+github.com/creack/goselect v0.1.3-0.20221130125424-8eac7f782437 h1:vR0VDJLclKuJceyXLWbj8ZFPvUvOkSSQ6fJ63R4pzRY=
+github.com/creack/goselect v0.1.3-0.20221130125424-8eac7f782437/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/serial_test.go
+++ b/serial_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/albenik/go-serial/v2"
+	"github.com/bclswl0827/go-serial/v2"
 )
 
 func TestPortNilReciever_Error(t *testing.T) {

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/multierr"
 	"golang.org/x/sys/unix"
 
-	"github.com/albenik/go-serial/v2/unixutils"
+	"github.com/bclswl0827/go-serial/v2/unixutils"
 )
 
 const FIONREAD = 0x541B


### PR DESCRIPTION
This PR fixes the problem of `undefined: NFDBITS` when building for loong64