### PR TITLE
Fix applyModemBitsStatus (unix)

### DIFF
--- a/serial_unix.go
+++ b/serial_unix.go
@@ -382,7 +382,7 @@ func (p *Port) retrieveModemBitsStatus() (int, error) {
 }
 
 func (p *Port) applyModemBitsStatus(status int) error {
-	if err := unix.IoctlSetInt(p.internal.handle, unix.TIOCMSET, status); err != nil {
+	if err := unix.IoctlSetPointerInt(p.internal.handle, unix.TIOCMSET, status); err != nil {
 		return newPortOSError(err)
 	}
 	return nil


### PR DESCRIPTION
Use IoctlSetPointerInt instead of IoctlSetInt