### PR TITLE
Bump GitHub action workflows to latest versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,4 +66,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -18,15 +18,15 @@ jobs:
           - 'macos-latest'
           - 'windows-latest'
         go:
-          - '1.19'
           - '1.20'
           - '1.21'
+          - '1.22'
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - run: go test -v -race ./...
@@ -38,20 +38,20 @@ jobs:
   #    strategy:
   #      matrix:
   #        go:
-  #          - 1.16
-  #          - 1.17
-  #          - 1.18
+  #          - 1.20
+  #          - 1.21
+  #          - 1.22
   #
   #    runs-on: ubuntu-latest
   #
   #    steps:
-  #      - uses: actions/checkout@v2
-  #      - uses: actions/setup-go@v2
+  #      - uses: actions/checkout@v4
+  #      - uses: actions/setup-go@v5
   #        with:
   #          go-version: ${{ matrix.go }}
-  #      - uses: golangci/golangci-lint-action@v2
+  #      - uses: golangci/golangci-lint-action@v4
   #        with:
-  #          version: v1.45
+  #          version: v1.57.2
 
   # Build
   build:
@@ -95,5 +95,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - run: uname -a && go build


### PR DESCRIPTION
This PR bumps GitHub action workflows to latest versions, thus avoiding deprecation warnings as e.g. seen [here](https://github.com/albenik/go-serial/actions/runs/7688699812).